### PR TITLE
dual

### DIFF
--- a/doc/presenter.tex
+++ b/doc/presenter.tex
@@ -23,7 +23,7 @@
 \NewDocumentCommand{\presenter}{}{\textsc{Presenter}}
 \title{\presenter: A \LaTeX{} presentation framework with seamless migration}
 \author{Log Creative}
-\date{2023-03-17 \quad v0.2.0}
+\date{2023-06-24 \quad v0.2.5}
 
 \begin{document}
 

--- a/source/presenter.dtx
+++ b/source/presenter.dtx
@@ -24,7 +24,7 @@
 %<class>\ProvidesExplClass
 %<package>\ProvidesExplPackage
   {presenter}
-  {2023-03-17}{v0.2.0}
+  {2023-06-24}{v0.2.5}
 %<class>  {A LaTeX presentation framework with seamless migration (class)}
 %<package>  {A LaTeX presentation framework with seamless migration (package)}
 %</class|package>

--- a/source/presenter.dtx
+++ b/source/presenter.dtx
@@ -164,10 +164,12 @@
 % Patch part page here if you want to use \cls{article} as the base class.
 % It is not harmful for \cls{report} base class as well, which will clear the
 % page twice in equivalence to clear the page once.
+% Process the part sectioning after clearing the page.
 %    \begin{macrocode}
 \xpretocmd { \part } {
   \clearpage
   \thispagestyle { plain }
+  \UseInstance { foreground / sectioning } { base } { part } { }
 } {  } {  }
 %    \end{macrocode}
 %

--- a/source/presenter.ins
+++ b/source/presenter.ins
@@ -43,6 +43,7 @@ The Current Maintainer of this work is Log Creative.
 \generate{\file{pretbg-block.sty}{\from{pretbg.dtx}{package,block}}}
 \generate{\file{pretbg-l3block.sty}{\from{pretbg.dtx}{package,l3block}}}
 \generate{\file{pretfg-default.sty}{\from{pretfg.dtx}{package,default}}}
+\generate{\file{pretfg-dual.sty}{\from{pretfg.dtx}{package,dual}}}
 
 \obeyspaces
 \Msg{**************************************************************}

--- a/source/pretbg.dtx
+++ b/source/pretbg.dtx
@@ -23,7 +23,7 @@
 %<default>  {pretbg-default}
 %<block>  {pretbg-block}
 %<l3block>  {pretbg-l3block}
-  {2023-03-17}{v0.2.0}
+  {2023-06-24}{v0.2.5}
 %<default>  {default background style for presenter}
 %<block>  {block background style for presenter}
 %<l3block>  {block background style for presenter implemented in l3draw}

--- a/source/pretfg.dtx
+++ b/source/pretfg.dtx
@@ -21,8 +21,10 @@
 \NeedsTeXFormat{LaTeX2e}[2020/10/01]
 \ProvidesExplPackage
 %<default>  {pretfg-default}
+%<dual>  {pretfg-dual}
   {2023-03-17}{v0.2.0}
 %<default>  {default foreground style for presenter}
+%<dual>  {dual foreground style for presenter}
 %</package>
 % \fi
 %
@@ -63,9 +65,51 @@
 %    \begin{macrocode}
 \DeclareTemplateInterface { foreground / footline } { default } { 0 }
   { style : tokenlist }
-%</default>
 %    \end{macrocode}
 % \end{TemplateDescription}
+%
+%    \begin{macrocode}
+%</default>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%<*dual>
+%    \end{macrocode}
+%
+% \begin{TemplateDescription}{foreground/headline}{dual}
+% \TemplateKey{parent-style}{tokenlist}{Style of parent level text}{\cs{normalsize}}
+% \TemplateKey{child-style}{tokenlist}{Style of main text}{\cs{Large}}
+% \TemplateSemantics Display the parent level (except the empty nodes) and the current level titles.
+%    \begin{macrocode}
+\DeclareTemplateInterface { foreground / headline } { dual } { 0 }
+  { 
+    parent-style : tokenlist = \normalsize ,
+    child-style: tokenlist = \Large
+  }
+%    \end{macrocode}
+% \end{TemplateDescription}
+%
+% \begin{TemplateDescription}{foreground/sectioning}{dual}
+% \TemplateKey{none}{---}{}{}
+% \TemplateSemantics Handle sectioning marks.
+%    \begin{macrocode}
+\DeclareTemplateInterface { foreground / sectioning } { dual } { 2 }
+  { }
+%    \end{macrocode}
+% \end{TemplateDescription}
+%
+% \begin{TemplateDescription}{foreground/footline}{default}
+% \TemplateKey{none}{---}{}{}
+% \TemplateSemantics Default page number footline style.
+%    \begin{macrocode}
+\DeclareTemplateInterface { foreground / footline } { dual } { 0 }
+  { style : tokenlist }
+%    \end{macrocode}
+% \end{TemplateDescription}
+%
+%    \begin{macrocode}
+%</dual>
+%    \end{macrocode}
 %
 % \end{documentation}
 %
@@ -109,6 +153,96 @@
     \group_end:
   }
 %</default>
+%    \end{macrocode}
+%
+% \pkg{dual} style.
+%    \begin{macrocode}
+%<*dual>
+%<@@=pretfg_dual>
+\tl_new:N \l_@@_fg_headline_parent_style_tl
+\tl_new:N \l_@@_fg_headline_child_style_tl
+%    \end{macrocode}
+% \begin{variable}[int]{
+%   \l_@@_fg_headline_prev_sec_lv_int,
+%   \l_@@_fg_headline_cur_sec_lv_int
+% }
+% Store the previous or the current section level.
+% Here an int variable is used instead of a mark, since the mark grabbed by
+% \cs{LastMark} is not expandable and cannot be processed by \cs{int_eval:n}.
+%    \begin{macrocode}
+\int_new:N \l_@@_fg_headline_prev_sec_lv_int
+\int_set:Nn \l_@@_fg_headline_prev_sec_lv_int { 10 }
+\int_new:N \l_@@_fg_headline_cur_sec_lv_int
+%    \end{macrocode}
+% \end{variable}
+%    \begin{macrocode}
+\DebugMarksOn
+\NewMarkClass { pretprevmark }
+\NewMarkClass { pretcurmark }
+\DeclareTemplateCode { foreground / headline } { dual } { 0 }
+  {
+    parent-style = \l_@@_fg_headline_parent_style_tl ,
+    child-style = \l_@@_fg_headline_child_style_tl
+  }
+  {
+    \AssignTemplateKeys
+    \group_begin:
+      \mark_if_eq:nnnnnnTF { page } { pretprevmark } { last }
+        { page } { pretcurmark } { last }
+        {
+          \l_@@_fg_headline_child_style_tl 
+          \LastMark { pretcurmark }
+        }
+        {
+          % TODO: adjust
+          \begin{tabular}{@{}l@{}}
+            \l_@@_fg_headline_parent_style_tl \LastMark { pretprevmark } \\
+            \l_@@_fg_headline_child_style_tl \LastMark { pretcurmark }
+          \end{tabular}
+        }
+    \group_end:
+  }
+\DeclareTemplateCode { foreground / sectioning } { dual } { 2 }
+  { }
+  {
+    \tl_if_eq:nnTF { #1 } { star }
+      {
+        % TODO: handle star version. Use a tmp variable? Modify the criteria?
+        \InsertMark { pretprevmark } { #2 }
+        \InsertMark { pretcurmark } { #2 }
+      }
+      {
+        \tl_if_eq:nnTF { #1 } { part }
+          {
+            \int_set:Nn \l_@@_fg_headline_prev_sec_lv_int { 10 }
+          }
+          {
+            \pret_get_sec_lv:nN { #1 } \l_@@_fg_headline_cur_sec_lv_int
+            \int_compare:nNnTF
+              { \l_@@_fg_headline_cur_sec_lv_int } > 
+              { \l_@@_fg_headline_prev_sec_lv_int }
+              { \InsertMark { pretcurmark } { #2 } }
+              {
+                \int_set_eq:NN \l_@@_fg_headline_prev_sec_lv_int
+                  \l_@@_fg_headline_cur_sec_lv_int
+                \InsertMark { pretprevmark } { #2 }
+                \InsertMark { pretcurmark } { #2 }
+              }
+          }
+      }
+  }
+\tl_new:N \l_@@_fg_footline_style_tl
+\DeclareTemplateCode { foreground / footline } { dual } { 0 }
+  { style = \l_@@_fg_footline_style_tl }
+  {
+    \AssignTemplateKeys
+    \hfil
+    \group_begin:
+      \l_@@_fg_footline_style_tl
+      \thepage
+    \group_end:
+  }
+%</dual>
 %    \end{macrocode}
 %
 % \end{implementation}

--- a/source/pretfg.dtx
+++ b/source/pretfg.dtx
@@ -198,26 +198,27 @@
   }
   {
     \AssignTemplateKeys
-    \group_begin:
-      \mark_if_eq:nnnnnnTF { page } { pretprevmark } { last }
-        { page } { pretcurmark } { last }
-        {
+    \mark_if_eq:nnnnnnTF { page } { pretprevmark } { last }
+      { page } { pretcurmark } { last }
+      {
+        \group_begin:
           \l_@@_fg_headline_child_style_tl 
           \LastMark { pretcurmark }
+        \group_end:
+        \hfil
+      }
+      {
+        \vbox_set:Nn \l_@@_fg_headline_parent_box 
+          { \l_@@_fg_headline_parent_style_tl \LastMark { pretprevmark } }
+        \vbox:n {
+          \skip_vertical:n { - \box_ht_plus_dp:N \l_@@_fg_headline_parent_box }
+          \begin{tabular}{@{}l@{}}
+            \l_@@_fg_headline_parent_style_tl \LastMark { pretprevmark } \\
+            \l_@@_fg_headline_child_style_tl \LastMark { pretcurmark }
+          \end{tabular}
+          \skip_vertical:n { \box_ht_plus_dp:N \l_@@_fg_headline_parent_box }
         }
-        {
-          \vbox_set:Nn \l_@@_fg_headline_parent_box 
-            { \l_@@_fg_headline_parent_style_tl \LastMark { pretprevmark } }
-          \vbox:n {
-            \skip_vertical:n { - \box_ht_plus_dp:N \l_@@_fg_headline_parent_box }
-            \begin{tabular}{@{}l@{}}
-              \l_@@_fg_headline_parent_style_tl \LastMark { pretprevmark } \\
-              \l_@@_fg_headline_child_style_tl \LastMark { pretcurmark }
-            \end{tabular}
-            \skip_vertical:n { \box_ht_plus_dp:N \l_@@_fg_headline_parent_box }
-          }
-        }
-    \group_end:
+      }
   }
 \DeclareTemplateCode { foreground / sectioning } { dual } { 2 }
   { }

--- a/source/pretfg.dtx
+++ b/source/pretfg.dtx
@@ -22,7 +22,7 @@
 \ProvidesExplPackage
 %<default>  {pretfg-default}
 %<dual>  {pretfg-dual}
-  {2023-03-17}{v0.2.0}
+  {2023-06-24}{v0.2.5}
 %<default>  {default foreground style for presenter}
 %<dual>  {dual foreground style for presenter}
 %</package>

--- a/source/pretfg.dtx
+++ b/source/pretfg.dtx
@@ -195,6 +195,8 @@
 % FIXME: the vertical skip before and after the \env{tabular} seems to have a
 % maximum value which cannot be exceeded. Maybe related to \pkg{geometry}
 % package or the \cs{vbox} without height?
+%
+% FIXME: overfull vbox, the implementation is required to be refactored.
 %    \begin{macrocode}
 \DeclareTemplateCode { foreground / headline } { dual } { 0 }
   {

--- a/source/pretfg.dtx
+++ b/source/pretfg.dtx
@@ -244,8 +244,8 @@
           }
         }
       }
-      \group_end:
-      \hfil
+    \group_end:
+    \hfil
   }
 \DeclareTemplateCode { foreground / sectioning } { dual } { 2 }
   { }

--- a/source/pretfg.dtx
+++ b/source/pretfg.dtx
@@ -251,7 +251,10 @@
             \int_compare:nNnTF
               { \l_@@_fg_headline_cur_sec_lv_int } > 
               { \l_@@_fg_headline_prev_sec_lv_int }
-              { \InsertMark { pretcurmark } { #2 } }
+              { 
+                \InsertMark { pretprevmark } { \LastMark { pretcurmark } }
+                \InsertMark { pretcurmark } { #2 }
+              }
               {
                 \int_set_eq:NN \l_@@_fg_headline_prev_sec_lv_int
                   \l_@@_fg_headline_cur_sec_lv_int

--- a/source/pretfg.dtx
+++ b/source/pretfg.dtx
@@ -160,6 +160,13 @@
 %<*dual>
 %<@@=pretfg_dual>
 %    \end{macrocode}
+% \begin{variable}[int]{\c_@@_fg_headline_lowest_sec_lv_int}
+% The lowest section level constant.
+% FIXME: Maybe refactored.
+%    \begin{macrocode}
+\int_const:Nn \c_@@_fg_headline_lowest_sec_lv_int { 10 }
+%    \end{macrocode}
+% \end{variable}
 % \begin{variable}[int]{
 %   \l_@@_fg_headline_prev_sec_lv_int,
 %   \l_@@_fg_headline_cur_sec_lv_int
@@ -169,7 +176,8 @@
 % \cs{LastMark} is not expandable and cannot be processed by \cs{int_eval:n}.
 %    \begin{macrocode}
 \int_new:N \l_@@_fg_headline_prev_sec_lv_int
-\int_set:Nn \l_@@_fg_headline_prev_sec_lv_int { 10 }
+\int_set_eq:NN \l_@@_fg_headline_prev_sec_lv_int
+  \c_@@_fg_headline_lowest_sec_lv_int
 \int_new:N \l_@@_fg_headline_cur_sec_lv_int
 %    \end{macrocode}
 % \end{variable}
@@ -246,7 +254,8 @@
         \bool_set_false:N \l_@@_fg_headline_star_mark_bool
         \tl_if_eq:nnTF { #1 } { part }
           {
-            \int_set:Nn \l_@@_fg_headline_prev_sec_lv_int { 10 }
+            \int_set:Nn \l_@@_fg_headline_prev_sec_lv_int 
+              \c_@@_fg_headline_lowest_sec_lv_int
           }
           {
             \pret_get_sec_lv:nN { #1 } \l_@@_fg_headline_cur_sec_lv_int

--- a/source/pretfg.dtx
+++ b/source/pretfg.dtx
@@ -181,14 +181,19 @@
 \int_new:N \l_@@_fg_headline_cur_sec_lv_int
 %    \end{macrocode}
 % \end{variable}
+% \begin{variable}[int]{\l_@@_fg_headline_star_mark_bool}
+% Boolean variable to indicate whether this page is a stared section or not.
+%    \begin{macrocode}
+\bool_new:N \l_@@_fg_headline_star_mark_bool
+\bool_set_false:N \l_@@_fg_headline_star_mark_bool
+%    \end{macrocode}
+% \end{variable}
 %
 % FIXME: Maybe mark is not necessary.
 %    \begin{macrocode}
 \NewMarkClass { pretprevmark }
 \NewMarkClass { pretcurmark }
 \NewMarkClass { pretstarmark }
-\bool_new:N \l_@@_fg_headline_star_mark_bool
-\bool_set_false:N \l_@@_fg_headline_star_mark_bool
 \tl_new:N \l_@@_fg_headline_parent_style_tl
 \tl_new:N \l_@@_fg_headline_child_style_tl
 \box_new:N \l_@@_fg_headline_parent_box

--- a/source/pretfg.dtx
+++ b/source/pretfg.dtx
@@ -173,9 +173,14 @@
 \int_new:N \l_@@_fg_headline_cur_sec_lv_int
 %    \end{macrocode}
 % \end{variable}
+%
+% FIXME: Maybe mark is not necessary.
 %    \begin{macrocode}
 \NewMarkClass { pretprevmark }
 \NewMarkClass { pretcurmark }
+\NewMarkClass { pretstarmark }
+\bool_new:N \l_@@_fg_headline_star_mark_bool
+\bool_set_false:N \l_@@_fg_headline_star_mark_bool
 \tl_new:N \l_@@_fg_headline_parent_style_tl
 \tl_new:N \l_@@_fg_headline_child_style_tl
 \box_new:N \l_@@_fg_headline_parent_box
@@ -198,38 +203,45 @@
   }
   {
     \AssignTemplateKeys
-    \mark_if_eq:nnnnnnTF { page } { pretprevmark } { last }
-      { page } { pretcurmark } { last }
+    \group_begin:
+    \bool_if:NTF \l_@@_fg_headline_star_mark_bool
       {
-        \group_begin:
+        \l_@@_fg_headline_child_style_tl 
+        \LastMark { pretstarmark }
+      }
+      {
+        \mark_if_eq:nnnnnnTF { page } { pretprevmark } { last }
+        { page } { pretcurmark } { last }
+        {
           \l_@@_fg_headline_child_style_tl 
           \LastMark { pretcurmark }
-        \group_end:
-        \hfil
-      }
-      {
-        \vbox_set:Nn \l_@@_fg_headline_parent_box 
-          { \l_@@_fg_headline_parent_style_tl \LastMark { pretprevmark } }
-        \vbox:n {
-          \skip_vertical:n { - \box_ht_plus_dp:N \l_@@_fg_headline_parent_box }
-          \begin{tabular}{@{}l@{}}
-            \l_@@_fg_headline_parent_style_tl \LastMark { pretprevmark } \\
-            \l_@@_fg_headline_child_style_tl \LastMark { pretcurmark }
-          \end{tabular}
-          \skip_vertical:n { \box_ht_plus_dp:N \l_@@_fg_headline_parent_box }
+        }
+        {
+          \vbox_set:Nn \l_@@_fg_headline_parent_box 
+            { \l_@@_fg_headline_parent_style_tl \LastMark { pretprevmark } }
+          \vbox:n {
+            \skip_vertical:n { - \box_ht_plus_dp:N \l_@@_fg_headline_parent_box }
+            \begin{tabular}{@{}l@{}}
+              \l_@@_fg_headline_parent_style_tl \LastMark { pretprevmark } \\
+              \l_@@_fg_headline_child_style_tl \LastMark { pretcurmark }
+            \end{tabular}
+            \skip_vertical:n { \box_ht_plus_dp:N \l_@@_fg_headline_parent_box }
+          }
         }
       }
+      \group_end:
+      \hfil
   }
 \DeclareTemplateCode { foreground / sectioning } { dual } { 2 }
   { }
   {
     \tl_if_eq:nnTF { #1 } { star }
       {
-        % TODO: handle star version. Use a tmp variable? Modify the criteria?
-        \InsertMark { pretprevmark } { #2 }
-        \InsertMark { pretcurmark } { #2 }
+        \bool_set_true:N \l_@@_fg_headline_star_mark_bool
+        \InsertMark { pretstarmark } { #2 }
       }
       {
+        \bool_set_false:N \l_@@_fg_headline_star_mark_bool
         \tl_if_eq:nnTF { #1 } { part }
           {
             \int_set:Nn \l_@@_fg_headline_prev_sec_lv_int { 10 }

--- a/source/pretfg.dtx
+++ b/source/pretfg.dtx
@@ -159,8 +159,6 @@
 %    \begin{macrocode}
 %<*dual>
 %<@@=pretfg_dual>
-\tl_new:N \l_@@_fg_headline_parent_style_tl
-\tl_new:N \l_@@_fg_headline_child_style_tl
 %    \end{macrocode}
 % \begin{variable}[int]{
 %   \l_@@_fg_headline_prev_sec_lv_int,
@@ -176,9 +174,23 @@
 %    \end{macrocode}
 % \end{variable}
 %    \begin{macrocode}
-\DebugMarksOn
 \NewMarkClass { pretprevmark }
 \NewMarkClass { pretcurmark }
+\tl_new:N \l_@@_fg_headline_parent_style_tl
+\tl_new:N \l_@@_fg_headline_child_style_tl
+\box_new:N \l_@@_fg_headline_parent_box
+%    \end{macrocode}
+% It seems to be in horizontal mode in the header, use a \cs{vbox} to create a
+% vertical mode environment in order to adjust the vertical position of the
+% titles.
+%
+% A \env{tabular} environment is used to make natural vertical spaces without 
+% manual adjustments.
+%
+% FIXME: the vertical skip before and after the \env{tabular} seems to have a
+% maximum value which cannot be exceeded. Maybe related to \pkg{geometry}
+% package or the \cs{vbox} without height?
+%    \begin{macrocode}
 \DeclareTemplateCode { foreground / headline } { dual } { 0 }
   {
     parent-style = \l_@@_fg_headline_parent_style_tl ,
@@ -194,11 +206,16 @@
           \LastMark { pretcurmark }
         }
         {
-          % TODO: adjust
-          \begin{tabular}{@{}l@{}}
-            \l_@@_fg_headline_parent_style_tl \LastMark { pretprevmark } \\
-            \l_@@_fg_headline_child_style_tl \LastMark { pretcurmark }
-          \end{tabular}
+          \vbox_set:Nn \l_@@_fg_headline_parent_box 
+            { \l_@@_fg_headline_parent_style_tl \LastMark { pretprevmark } }
+          \vbox:n {
+            \skip_vertical:n { - \box_ht_plus_dp:N \l_@@_fg_headline_parent_box }
+            \begin{tabular}{@{}l@{}}
+              \l_@@_fg_headline_parent_style_tl \LastMark { pretprevmark } \\
+              \l_@@_fg_headline_child_style_tl \LastMark { pretcurmark }
+            \end{tabular}
+            \skip_vertical:n { \box_ht_plus_dp:N \l_@@_fg_headline_parent_box }
+          }
         }
     \group_end:
   }

--- a/testfiles/dual.lvt
+++ b/testfiles/dual.lvt
@@ -1,0 +1,47 @@
+\input{regression-test}
+\documentclass{presenter}
+\LoadPresenterForeground{dual}
+\vfuzz=18pt
+\begin{document}
+\START
+\part{Example}
+
+Testing the text under the part.
+
+\section{A segment}
+
+Testing the text in the section.
+
+\subsection{A small segment}
+
+Testing the text in the subsection.
+
+\subsubsection{A very small segment}
+
+Testing the text in the subsubsection.
+
+\paragraph{A point}
+
+Testing the text in the paragraph.
+
+\subparagraph{A small point}
+
+Testing the text in the subparagraph.
+
+\subparagraph*{Star page}
+
+Testing the stared sectioning.
+
+\part{Another part}
+
+Testing the sectioning after another part.
+
+\section{New section}
+
+This is a new section in the second part.
+
+\subsection{subsection in the section}
+
+This is the subsection in the section and the second part.
+
+\end{document}

--- a/testfiles/dual.tlg
+++ b/testfiles/dual.tlg
@@ -1,0 +1,18 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+[1
+] [2
+]
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <7> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <5> on input line ....
+[3
+] [4
+] [5
+] [6
+] [7
+] [8
+] [9
+] [10
+] (dual.aux)


### PR DESCRIPTION
Foreground template `dual` implementation.

FIXME:
- overfull `\vbox`: required refactoring on displaying the two lines of titles.
- mark may not be necessary.